### PR TITLE
Implement CalendarData.GetCalendars and JapaneseCalendar eras

### DIFF
--- a/src/mscorlib/corefx/Interop/Unix/System.Globalization.Native/Interop.Calendar.cs
+++ b/src/mscorlib/corefx/Interop/Unix/System.Globalization.Native/Interop.Calendar.cs
@@ -15,6 +15,9 @@ internal static partial class Interop
            IntPtr context);
 
         [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode)]
+        internal static extern int GetCalendars(string localeName, CalendarId[] calendars, int calendarsCapacity);
+
+        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode)]
         internal static extern CalendarDataResult GetCalendarInfo(string localeName, CalendarId calendarId, CalendarDataType calendarDataType, StringBuilder result, int resultCapacity);
 
         [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode)]

--- a/src/mscorlib/corefx/Interop/Unix/System.Globalization.Native/Interop.Calendar.cs
+++ b/src/mscorlib/corefx/Interop/Unix/System.Globalization.Native/Interop.Calendar.cs
@@ -23,5 +23,11 @@ internal static partial class Interop
         [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode)]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool EnumCalendarInfo(EnumCalendarInfoCallback callback, string localeName, CalendarId calendarId, CalendarDataType calendarDataType, IntPtr context);
+
+        [DllImport(Libraries.GlobalizationInterop)]
+        internal static extern int GetLatestJapaneseEra();
+
+        [DllImport(Libraries.GlobalizationInterop)]
+        internal static extern bool GetJapaneseEraStartDate(int era, out int startYear, out int startMonth, out int startDay);
     }
 }

--- a/src/mscorlib/corefx/System/Globalization/CalendarData.Unix.cs
+++ b/src/mscorlib/corefx/System/Globalization/CalendarData.Unix.cs
@@ -119,7 +119,7 @@ namespace System.Globalization
             return false;
         }
 
-        private static bool EnumCalendarInfo(string localeName, CalendarId calendarId, CalendarDataType dataType, out string[] calendarData)
+        internal static bool EnumCalendarInfo(string localeName, CalendarId calendarId, CalendarDataType dataType, out string[] calendarData)
         {
             calendarData = null;
 

--- a/src/mscorlib/corefx/System/Globalization/CalendarData.Unix.cs
+++ b/src/mscorlib/corefx/System/Globalization/CalendarData.Unix.cs
@@ -69,8 +69,8 @@ namespace System.Globalization
         // Call native side to figure out which calendars are allowed
         internal static int GetCalendars(string localeName, bool useUserOverride, CalendarId[] calendars)
         {
-            // TODO: Implement this.
-            return 0;
+            // NOTE: there are no 'user overrides' on Linux
+            return Interop.GlobalizationInterop.GetCalendars(localeName, calendars, calendars.Length);
         }
 
         private static bool SystemSupportsTaiwaneseCalendar()

--- a/src/mscorlib/corefx/System/Globalization/JapaneseCalendar.Unix.cs
+++ b/src/mscorlib/corefx/System/Globalization/JapaneseCalendar.Unix.cs
@@ -1,24 +1,87 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
+
 namespace System.Globalization
 {
     public partial class JapaneseCalendar : Calendar
     {
-        private static int GetJapaneseEraCount()
+        private static EraInfo[] GetJapaneseEras()
         {
-            //UNIXTODO: Implement this fully.
-            return 0;
+            string[] eraNames;
+            if (!CalendarData.EnumCalendarInfo("ja-JP", CalendarId.JAPAN, CalendarDataType.EraNames, out eraNames))
+            {
+                return null;
+            }
+
+            string[] abbrevEnglishEraNames;
+            if (!CalendarData.EnumCalendarInfo("en", CalendarId.JAPAN, CalendarDataType.AbbrevEraNames, out abbrevEnglishEraNames))
+            {
+                return null;
+            }
+
+            List<EraInfo> eras = new List<EraInfo>();
+            int lastMaxYear = GregorianCalendar.MaxYear;
+
+            int latestEra = Interop.GlobalizationInterop.GetLatestJapaneseEra();
+            for (int i = latestEra; i >= 0; i--)
+            {
+                DateTime dt;
+                if (!GetJapaneseEraStartDate(i, out dt))
+                {
+                    return null;
+                }
+
+                if (dt < JapaneseCalendar.calendarMinValue)
+                {
+                    // only populate the Eras that are valid JapaneseCalendar date times
+                    break;
+                }
+
+                eras.Add(new EraInfo(i, dt.Year, dt.Month, dt.Day, dt.Year - 1, 1, lastMaxYear - dt.Year + 1,
+                    eraNames[i], GetAbbreviatedEraName(eraNames, i), abbrevEnglishEraNames[i]));
+
+                lastMaxYear = dt.Year;
+            }
+
+            // remap the Era numbers, now that we know how many there will be
+            for (int i = 0; i < eras.Count; i++)
+            {
+                eras[i].era = eras.Count - i;
+            }
+
+            return eras.ToArray();
         }
 
-        private static bool GetJapaneseEraInfo(int era, out DateTimeOffset dateOffset, out string eraName, out string abbreviatedEraName)
-        {
-            //UNIXTODO: Implement this fully.
-            dateOffset = default(DateTimeOffset);
-            eraName = null;
-            abbreviatedEraName = null;
+        // PAL Layer ends here
 
-            return false;
+        private static string GetAbbreviatedEraName(string[] eraNames, int eraIndex)
+        {
+            // This matches the behavior on Win32 - only returning the first character of the era name.
+            // See Calendar.EraAsString(Int32) - https://msdn.microsoft.com/en-us/library/windows/apps/br206751.aspx
+            return eraNames[eraIndex].Substring(0, 1);
+        }
+
+        private static bool GetJapaneseEraStartDate(int era, out DateTime dateTime)
+        {
+            dateTime = default(DateTime);
+
+            int startYear;
+            int startMonth;
+            int startDay;
+            bool result = Interop.GlobalizationInterop.GetJapaneseEraStartDate(
+                era,
+                out startYear,
+                out startMonth,
+                out startDay);
+
+            if (result)
+            {
+                dateTime = new DateTime(startYear, startMonth, startDay);
+            }
+
+            return result;
         }
     }
 }

--- a/src/mscorlib/corefx/System/Globalization/JapaneseCalendar.cs
+++ b/src/mscorlib/corefx/System/Globalization/JapaneseCalendar.cs
@@ -124,49 +124,6 @@ namespace System.Globalization
             return japaneseEraInfo;
         }
 
-        private static EraInfo[] GetJapaneseEras()
-        {
-            int erasCount = GetJapaneseEraCount();
-            if (erasCount < 4)
-            {
-                return null;
-            }
-
-            EraInfo[] eras = new EraInfo[erasCount];
-            int lastMaxYear = GregorianCalendar.MaxYear;
-
-            for (int i = erasCount; i > 0; i--)
-            {
-                DateTimeOffset dateOffset;
-
-                string eraName;
-                string abbreviatedEraName;
-
-                if (!GetJapaneseEraInfo(i, out dateOffset, out eraName, out abbreviatedEraName))
-                {
-                    return null;
-                }
-
-                DateTime dt = new DateTime(dateOffset.Ticks);
-
-                eras[erasCount - i] = new EraInfo(i, dt.Year, dt.Month, dt.Day, dt.Year - 1, 1, lastMaxYear - dt.Year + 1,
-                                                   eraName, abbreviatedEraName, GetJapaneseEnglishEraName(i));    // era #4 start year/month/day, yearOffset, minEraYear
-
-                lastMaxYear = dt.Year;
-            }
-
-            return eras;
-        }
-
-        private static string[] JapaneseErasEnglishNames = new String[] { "M", "T", "S", "H" };
-
-        private static string GetJapaneseEnglishEraName(int era)
-        {
-            Debug.Assert(era > 0);
-            return era <= JapaneseErasEnglishNames.Length ? JapaneseErasEnglishNames[era - 1] : " ";
-        }
-
-
         internal static volatile Calendar s_defaultInstance;
         internal GregorianCalendarHelper helper;
 


### PR DESCRIPTION
Implementing CalendarData.GetCalendars to get the list of available calendars for each culture.  ICU has some differences in calendar preferences vs. Windows for certain cultures.

Getting JapaneseCalendar era information from ICU.  Only retrieving the eras that are in the JapaneseCalendar timeframe (1868/09/08 - DateTime.MaxValue).  Currently there are 4 eras.  CLDR doesn't have abbreviated Japanese era names.  On Windows, the JapaneseCalendar returns just the first character for the abbreviated era name.  I made the Unix implementation the same by just returning the first character.
