### PR TITLE
Use 'readlink' of the /etc/localtime file to determine the TimeZoneInfo.Local.Id

### DIFF
--- a/src/corefx/System.Globalization.Native/CMakeLists.txt
+++ b/src/corefx/System.Globalization.Native/CMakeLists.txt
@@ -37,6 +37,7 @@ set(NATIVEGLOBALIZATION_SOURCES
     localeNumberData.cpp
     localeStringData.cpp
     normalization.cpp
+    timeZoneInfo.cpp
 )
 
 include_directories(${UTYPES_H})

--- a/src/corefx/System.Globalization.Native/timeZoneInfo.cpp
+++ b/src/corefx/System.Globalization.Native/timeZoneInfo.cpp
@@ -1,0 +1,24 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+#include <stdint.h>
+#include <unistd.h>
+
+/*
+Function:
+ReadLink
+
+Gets the symlink value for the path.
+*/
+extern "C" int32_t ReadLink(const char* path, char* result, size_t resultCapacity)
+{
+	ssize_t r = readlink(path, result, resultCapacity - 1); // subtract one to make room for the NULL character
+
+	if (r < 1 || r >= resultCapacity)
+		return false;
+
+	result[r] = '\0';
+	return true;
+}

--- a/src/mscorlib/corefx/Interop/Unix/System.Globalization.Native/Interop.TimeZoneInfo.cs
+++ b/src/mscorlib/corefx/Interop/Unix/System.Globalization.Native/Interop.TimeZoneInfo.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.InteropServices;
+using System.Text;
+
+internal static partial class Interop
+{
+    internal static partial class GlobalizationInterop
+    {
+        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Ansi)] // readlink requires char*
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool ReadLink(string filePath, StringBuilder result, uint resultCapacity);
+    }
+}

--- a/src/mscorlib/mscorlib.shared.sources.props
+++ b/src/mscorlib/mscorlib.shared.sources.props
@@ -784,6 +784,7 @@
     <GlobalizationSources Include="$(CoreFxSourcesRoot)\Interop\Unix\System.Globalization.Native\Interop.Calendar.cs" />
     <GlobalizationSources Include="$(CoreFxSourcesRoot)\Interop\Unix\System.Globalization.Native\Interop.Casing.cs" />
     <GlobalizationSources Include="$(CoreFxSourcesRoot)\Interop\Unix\System.Globalization.Native\Interop.Locale.cs" />
+    <GlobalizationSources Include="$(CoreFxSourcesRoot)\Interop\Unix\System.Globalization.Native\Interop.TimeZoneInfo.cs" />
     <GlobalizationSources Include="$(CoreFxSourcesRoot)\System\Globalization\CalendarData.Unix.cs" />
     <GlobalizationSources Include="$(CoreFxSourcesRoot)\System\Globalization\CompareInfo.Unix.cs" />
     <GlobalizationSources Include="$(CoreFxSourcesRoot)\System\Globalization\CultureData.Unix.cs" />

--- a/src/mscorlib/src/System/TimeZoneInfo.cs
+++ b/src/mscorlib/src/System/TimeZoneInfo.cs
@@ -2302,8 +2302,12 @@ namespace System {
                     rawData = File.ReadAllBytes(tzFilePath);
                     if (string.IsNullOrEmpty(id))
                     {
-                        // UNIXTODO: optimzation - see if tzFilePath is a symlink, and use 'readlink' to get the id 
-                        id = FindTimeZoneId(rawData);
+                        id = FindTimeZoneIdUsingReadLink(tzFilePath);
+
+                        if (string.IsNullOrEmpty(id))
+                        {
+                            id = FindTimeZoneId(rawData);
+                        }
                     }
                     return true;
                 }
@@ -2312,6 +2316,34 @@ namespace System {
                 catch (UnauthorizedAccessException) { }
             }
             return false;
+        }
+
+        /// <summary>
+        /// Finds the time zone id by using 'readlink' on the path to see if tzFilePath is
+        /// a symlink to a file 
+        /// </summary>
+        private static string FindTimeZoneIdUsingReadLink(string tzFilePath)
+        {
+            string id = null;
+
+            StringBuilder symlinkPathBuilder = StringBuilderCache.Acquire(Path.MaxPath);
+            bool result = Interop.GlobalizationInterop.ReadLink(tzFilePath, symlinkPathBuilder, (uint)symlinkPathBuilder.Capacity);
+            if (result)
+            {
+                string symlinkPath = StringBuilderCache.GetStringAndRelease(symlinkPathBuilder);
+                // time zone Ids have to point under the time zone directory
+                string timeZoneDirectory = GetTimeZoneDirectory();
+                if (symlinkPath.StartsWith(timeZoneDirectory))
+                {
+                    id = symlinkPath.Substring(timeZoneDirectory.Length);
+                }
+            }
+            else
+            {
+                StringBuilderCache.Release(symlinkPathBuilder);
+            }
+
+            return id;
         }
 
         /// <summary>


### PR DESCRIPTION
Use 'readlink' of the /etc/localtime file to determine the TimeZoneInfo.Local.Id

Fix https://github.com/dotnet/corefx/issues/2489.

@tarekgh, @steveharter, @ellismg 
