### PR TITLE
Update Trim* family for performance gain

### DIFF
--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -7234,8 +7234,8 @@
       <Member Name="Trim(System.Char)" />
       <Member Name="Trim(System.Char[])" />
       <Member Name="TrimStart" />
-      <Member Name="TrimStart(System.Char[])" />
       <Member Name="TrimStart(System.Char)" />
+      <Member Name="TrimStart(System.Char[])" />
       <Member Name="TrimEnd" />
       <Member Name="TrimEnd(System.Char)" />
       <Member Name="TrimEnd(System.Char[])" />

--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -7231,9 +7231,14 @@
       <Member Name="ToUpper(System.Globalization.CultureInfo)" />
       <Member Name="ToUpperInvariant" />
       <Member Name="Trim" />
+      <Member Name="Trim(System.Char)" />
       <Member Name="Trim(System.Char[])" />
-      <Member Name="TrimEnd(System.Char[])" />
+      <Member Name="TrimStart" />
       <Member Name="TrimStart(System.Char[])" />
+      <Member Name="TrimStart(System.Char)" />
+      <Member Name="TrimEnd" />
+      <Member Name="TrimEnd(System.Char)" />
+      <Member Name="TrimEnd(System.Char[])" />
       <Member MemberType="Property" Name="Chars(System.Int32)" />
       <Member MemberType="Property" Name="Length" />
       <Member Status="ImplRoot" Name="System.Collections.Generic.IEnumerable&lt;System.Char&gt;.GetEnumerator" />

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -1286,17 +1286,30 @@ namespace System {
 
             return result;
         }
-    
-    
-        // Removes a string of characters from the ends of this string.
+
         [Pure]
+        // Change trim to accept one char - just this block of code by Annie P
+        public String Trim(char trimChar) {
+            Contract.Ensures(Contract.Result<String>() != null);
+            Contract.EndContractBlock();
+
+            return TrimHelper(trimChar, TrimBoth);
+        }
+        // Removes a string of characters from the ends of this string.
         public String Trim(params char[] trimChars) {
             if (null==trimChars || trimChars.Length == 0) {
                 return TrimHelper(TrimBoth);
             }
             return TrimHelper(trimChars,TrimBoth);
         }
-    
+
+        // Change trimStart to accept one char - just this block of code by Annie P
+        public String TrimStart(char trimChar) {
+            Contract.Ensures(Contract.Result<String>() != null);
+            Contract.EndContractBlock();
+
+            return TrimHelper(trimChar, TrimHead);
+        }
         // Removes a string of characters from the beginning of this string.
         public String TrimStart(params char[] trimChars) {
             if (null==trimChars || trimChars.Length == 0) {
@@ -1304,8 +1317,15 @@ namespace System {
             }
             return TrimHelper(trimChars,TrimHead);
         }
-    
-    
+
+        // Change trimEnd to accept one char - just this block of code by Annie P
+        public String TrimEnd(char trimChar)
+        {
+            Contract.Ensures(Contract.Result<String>() != null);
+            Contract.EndContractBlock();
+
+            return TrimHelper(trimChar, TrimTail);
+        }
         // Removes a string of characters from the end of this string.
         public String TrimEnd(params char[] trimChars) {
             if (null==trimChars || trimChars.Length == 0) {
@@ -1313,8 +1333,7 @@ namespace System {
             }
             return TrimHelper(trimChars,TrimTail);
         }
-    
-    
+
         // Creates a new string with the characters copied in from ptr. If
         // ptr is null, a 0-length string (like String.Empty) is returned.
         //
@@ -2704,7 +2723,23 @@ namespace System {
             return TrimHelper(TrimBoth);        
         }
 
-       
+        // Handles when TrimStart is called with null characters - just this block of code by Annie P
+        public String TrimStart()
+        {
+            Contract.Ensures(Contract.Result<String>() != null);
+            Contract.EndContractBlock();
+
+            return TrimHelper(TrimBoth);
+        }
+        // Handles when TrimStart is called with null characters - just this block of code by Annie P
+        public String TrimEnd()
+        {
+            Contract.Ensures(Contract.Result<String>() != null);
+            Contract.EndContractBlock();
+
+            return TrimHelper(TrimBoth);
+        }
+
         [System.Security.SecuritySafeCritical]  // auto-generated
         private String TrimHelper(int trimType) {
             //end will point to the first non-trimmed character on the right
@@ -2727,8 +2762,25 @@ namespace System {
 
             return CreateTrimmedString(start, end);
         }
-    
-    
+        // Handles when TrimHelper is called with one char - just this block of code by Annie P
+        [System.Security.SecuritySafeCritical]  // auto-generated
+        private String TrimHelper(char trimChars, int trimType)
+        {
+            //start will point to the first non-trimmed character on the Left
+            //end will point to the first non-trimmed character on the right
+            int start=0, end=this.Length-1;
+
+            // Walk through string, find 1st char not the same as char to trim from the left.
+            if (trimType != TrimTail)
+                for (start=0; start < this.Length; start++)
+                    if (trimChars != this[start]) break; 
+            // Walk through string, find 1st char not the same as char to trim from the right.
+            if (trimType != TrimHead)
+                for (end=this.Length-1; end >= start; end--)
+                    if (trimChars != this[end]) break;
+            // Now go trim the character
+            return CreateTrimmedString(start, end);
+        }
         [System.Security.SecuritySafeCritical]  // auto-generated
         private String TrimHelper(char[] trimChars, int trimType) {
             //end will point to the first non-trimmed character on the right
@@ -2765,7 +2817,6 @@ namespace System {
 
             return CreateTrimmedString(start, end);
         }
-
 
         [System.Security.SecurityCritical]  // auto-generated
         private String CreateTrimmedString(int start, int end) {

--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -18,9 +18,9 @@ namespace System {
     using System.Globalization;
     using System.Threading;
     using System.Collections;
-    using System.Collections.Generic;    
+    using System.Collections.Generic;
     using System.Runtime.CompilerServices;
-    using System.Runtime.InteropServices;    
+    using System.Runtime.InteropServices;
     using System.Runtime.Versioning;
     using Microsoft.Win32;
     using System.Diagnostics.Contracts;
@@ -2729,15 +2729,15 @@ namespace System {
             Contract.Ensures(Contract.Result<String>() != null);
             Contract.EndContractBlock();
 
-            return TrimHelper(TrimBoth);
+            return TrimHelper(TrimHead);
         }
-        // Handles when TrimStart is called with null characters - just this block of code by Annie P
+        // Handles when TrimEnd is called with null characters - just this block of code by Annie P
         public String TrimEnd()
         {
             Contract.Ensures(Contract.Result<String>() != null);
             Contract.EndContractBlock();
 
-            return TrimHelper(TrimBoth);
+            return TrimHelper(TrimTail);
         }
 
         [System.Security.SecuritySafeCritical]  // auto-generated
@@ -2763,7 +2763,6 @@ namespace System {
             return CreateTrimmedString(start, end);
         }
         // Handles when TrimHelper is called with one char - just this block of code by Annie P
-        [System.Security.SecuritySafeCritical]  // auto-generated
         private String TrimHelper(char trimChars, int trimType)
         {
             //start will point to the first non-trimmed character on the Left


### PR DESCRIPTION
Instead of char[], we expand the trim\* family to handle one char.  I also updated the code to handle trim\* family with null char.

Added: Trim(), TrimStart(), TrimEnd(), Trim (char TrimChar), TrimStart (char TrimChar), TrimEnd (char TrimChar) and TrimHelper(Char TrimChar, int...)
